### PR TITLE
Update Readme to include password_confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Advanced Usage
 
-    user> (create-account! "foo@bar.com" :password "foobar" :newsletter false)
+    user> (create-account! "foo@bar.com" :password "foobar" :password_confirmation "foobar" :newsletter false)
     {:api-key "cfe16172146139fce0ffda2565ba3035", :password "foobar"}
     user> (account-active?)
     true


### PR DESCRIPTION
Account creation requires password_confirmation be sent if password is. Updating docs to reflect this.

This had not previously been enforced in the API, but it will be soon.
